### PR TITLE
Fix electron build config and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-boltelectron
+# Vyapar SaaS Electron
+
+This project is an Electron based desktop application that bundles a React front-end built with Vite. It provides billing and inventory features similar to the Vyapar SaaS requirements.
+
+## Development
+
+1. Install Node.js (v18 or later recommended).
+2. Run `npm install` in the project root to install both Electron and front-end dependencies.
+3. Start the app in development mode:
+   ```bash
+   npm run dev
+   ```
+   This starts the Vite dev server for the React code and launches Electron pointing to it.
+
+## Building
+
+To create a distributable desktop package run:
+
+```bash
+npm run build
+```
+
+The build will output installers or executables for your platform inside the `dist` folder (configured via `electron-builder`).
+
+## Running a Production Build
+
+After running `npm run build`, execute the generated file from the `dist` directory. On Windows this is typically an `.exe` installer, on Linux an `AppImage`, and on macOS a `.dmg` or `.app`.

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "baseUrl": ".",
+    "types": ["vite/client"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
     }
   },
   "devDependencies": {
-    "electron": "^latest",
-    "electron-builder": "^latest",
-    "concurrently": "^latest",
-    "wait-on": "^latest"
+    "electron": "^29.3.0",
+    "electron-builder": "^24.13.1",
+    "concurrently": "^8.2.2",
+    "wait-on": "^7.2.0"
   }
 }


### PR DESCRIPTION
## Summary
- add TypeScript config for the frontend
- set explicit versions for Electron dependencies
- document how to run and build the app

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_6884dc412c088323a244209cc4a295d8