### PR TITLE
Fix Electron dev mode detection

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -1,6 +1,6 @@
 const { app, BrowserWindow, Menu, ipcMain } = require('electron');
 const path = require('path');
-const isDev = process.env.NODE_ENV === 'development';
+const isDev = process.env.NODE_ENV === 'development' || !app.isPackaged;
 
 let mainWindow;
 


### PR DESCRIPTION
## Summary
- fix dev mode detection when running Electron directly

## Testing
- `node -c public/electron.js`
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6884e71434f48323aabadc14068d47d7