### PR TITLE
Fix property names for dashboard and reports

### DIFF
--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -274,7 +274,7 @@ const Dashboard: React.FC = () => {
                     {invoice.invoiceNumber}
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                    {invoice.customerName}
+                    {invoice.partyName}
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                     {new Date(invoice.date).toLocaleDateString()}

--- a/frontend/src/pages/Reports.tsx
+++ b/frontend/src/pages/Reports.tsx
@@ -145,7 +145,7 @@ const Reports: React.FC = () => {
               },
               {
                 title: 'Active Customers',
-                value: dashboardData.totalCustomers.toLocaleString(),
+                value: dashboardData.totalParties.toLocaleString(),
                 change: '+15.3%',
                 changeType: 'positive' as const,
                 icon: Users,


### PR DESCRIPTION
## Summary
- reference `partyName` rather than non-existent `customerName`
- use `totalParties` instead of `totalCustomers`

## Testing
- `npm run build` within `frontend`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6885588f7008832393511f6626eb869e