### PR TITLE
Add opening balance fields to party modal

### DIFF
--- a/frontend/src/pages/Customers.tsx
+++ b/frontend/src/pages/Customers.tsx
@@ -32,12 +32,17 @@ const AddPartyModal: React.FC<{
     billingAddress: '',
     shippingAddress: '',
     enableShippingAddress: false,
-    isActive: true
+    isActive: true,
+    creditLimit: undefined,
+    openingBalance: 0,
+    asOfDate: ''
   });
+  const [noCreditLimit, setNoCreditLimit] = useState(true);
 
   const handleSubmit = (saveAndNew = false) => {
     const newParty: Party = {
       ...formData,
+      creditLimit: noCreditLimit ? undefined : formData.creditLimit,
       id: Date.now().toString(),
       outstandingAmount: 0,
       totalPurchases: 0,
@@ -59,8 +64,12 @@ const AddPartyModal: React.FC<{
         billingAddress: '',
         shippingAddress: '',
         enableShippingAddress: false,
-        isActive: true
+        isActive: true,
+        creditLimit: undefined,
+        openingBalance: 0,
+        asOfDate: ''
       });
+      setNoCreditLimit(true);
     } else {
       onClose();
     }
@@ -232,17 +241,46 @@ const AddPartyModal: React.FC<{
 
           {activeTab === 'credit' && (
             <div className="space-y-4">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Opening Balance</label>
+                  <input
+                    type="number"
+                    value={formData.openingBalance || ''}
+                    onChange={(e) => setFormData(prev => ({ ...prev, openingBalance: parseFloat(e.target.value) || 0 }))}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                    placeholder="Opening Balance"
+                  />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">As of Date</label>
+                  <input
+                    type="date"
+                    value={formData.asOfDate || ''}
+                    onChange={(e) => setFormData(prev => ({ ...prev, asOfDate: e.target.value }))}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                  />
+                </div>
+              </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
-                  Credit Limit
+                <label className="flex items-center text-sm text-gray-700">
+                  <input
+                    type="checkbox"
+                    checked={noCreditLimit}
+                    onChange={(e) => setNoCreditLimit(e.target.checked)}
+                    className="mr-2 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                  />
+                  Credit Limit (No Limit)
                 </label>
-                <input
-                  type="number"
-                  value={formData.creditLimit || ''}
-                  onChange={(e) => setFormData(prev => ({ ...prev, creditLimit: parseFloat(e.target.value) || 0 }))}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                  placeholder="Enter credit limit"
-                />
+                {!noCreditLimit && (
+                  <input
+                    type="number"
+                    value={formData.creditLimit || ''}
+                    onChange={(e) => setFormData(prev => ({ ...prev, creditLimit: parseFloat(e.target.value) || 0 }))}
+                    className="mt-2 w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                    placeholder="Credit Limit"
+                  />
+                )}
               </div>
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -74,6 +74,8 @@ export interface Party {
   shippingAddress?: string;
   enableShippingAddress?: boolean;
   creditLimit?: number;
+  openingBalance?: number;
+  asOfDate?: string;
   outstandingAmount: number;
   totalPurchases: number;
   lastPurchaseDate?: string;


### PR DESCRIPTION
## Summary
- add `openingBalance` and `asOfDate` fields to `Party`
- extend Add Party modal with opening balance and no-limit credit toggle

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68855b15a2c08323a134f155491845c6